### PR TITLE
use HashHistory

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,4 +1,4 @@
-import { createRouter, createWebHistory } from "vue-router";
+import { createRouter, createWebHashHistory } from "vue-router";
 import Home from "@/views/home.vue";
 import Anime from "@/views/anime.vue";
 import Manga from "@/views/manga.vue";
@@ -62,7 +62,7 @@ const routes = [
 ];
 
 const router = createRouter({
-  history: createWebHistory(process.env.BASE_URL),
+  history: createWebHashHistory(process.env.BASE_URL),
   routes,
 });
 


### PR DESCRIPTION
because the deployment is on a static hosting site and other urls will throw 404, which can be fixed using hash method as everything gets fetched from "/#"